### PR TITLE
Issue#2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Instructions begin here:
   It must perform the appropriate operation on the two numbers in the order that
   they are presented. The included operations should be: `+`, `-`, `*`, `div`
   (`/` would change the URL path), and `%`. Its URL should be of the format
-  `/math/<num1><operation><num2>`.
+  `/math/<num1>/<operation>/<num2>`.
 
 Once all of your tests are passing, commit and push your work using `git` to
 submit.

--- a/server/app.py
+++ b/server/app.py
@@ -20,7 +20,7 @@ def count(number):
         count += f'{n}\n'
     return count
 
-@app.route('/math/<int:num1><string:operation><int:num2>')
+@app.route('/math/<int:num1>/<string:operation>/<int:num2>')
 def math(num1, num2, operation):
     if operation == '+':
         return str(num1 + num2)

--- a/server/testing/app_test.py
+++ b/server/testing/app_test.py
@@ -47,30 +47,30 @@ class TestApp:
 
     def test_math_route(self):
         '''has a resource available at "/math/<parameters>".'''
-        response = app.test_client().get('/math/5+5')
+        response = app.test_client().get('/math/5/+/5')
         assert(response.status_code == 200)
 
     def test_math_add(self):
         '''adds parameters in "/math/" resource when operation is "+".'''
-        response = app.test_client().get('/math/5+5')
+        response = app.test_client().get('/math/5/+/5')
         assert(response.data.decode() == '10')
 
     def test_math_subtract(self):
         '''subtracts parameters in "/math/" resource when operation is "-".'''
-        response = app.test_client().get('/math/5-5')
+        response = app.test_client().get('/math/5/-/5')
         assert(response.data.decode() == '0')
 
     def test_math_multiply(self):
         '''multiplies parameters in "/math/" resource when operation is "*".'''
-        response = app.test_client().get('/math/5*5')
+        response = app.test_client().get('/math/5/*/5')
         assert(response.data.decode() == '25')
 
     def test_math_divide(self):
         '''divides parameters in "/math/" resource when operation is "div".'''
-        response = app.test_client().get('/math/5div5')
+        response = app.test_client().get('/math/5/div/5')
         assert(response.data.decode() == '1.0')
     
     def test_math_modulo(self):
         '''finds remainder of parameters in "/math/" resource when operation is "%".'''
-        response = app.test_client().get('/math/5%5')
+        response = app.test_client().get('/math/5/%/5')
         assert(response.data.decode() == '0')


### PR DESCRIPTION
Fix for `num2` variable not working with an integer that has more than one digit. Adding slashes between the number and operation fixed the problem. 

```
http://localhost:5555/math/11/*/22
// 242

http://localhost:5555/math/11/div/22
// 0.5
```